### PR TITLE
Add CityReal under Society Simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,6 +656,7 @@ and Technology) et al. arXiv.* [[paper](https://arxiv.org/abs/2308.01423)]
 
 
 ### 3.3 Society Simulation with LLM-based Agents
+- [2026/07] **CityReal: Human-Aligned Urban Behavior and City Dynamics Simulation with Large-Scale LLM Agents.** *Nicolas Bougie (Woven by Toyota) et al. arXiv.* [[paper](https://arxiv.org/abs/2608.16897)]
 - [2024/03] **Emergence of Social Norms in Large Language Model-based Agent Societies.** *Siyue Ren et al. arXiv.* [[paper](https://arxiv.org/abs/2403.08251)] [[code](https://github.com/sxswz213/CRSEC)] 
 - [2023/08] **AgentSims: An Open-Source Sandbox for Large Language Model Evaluation.** *Jiaju Lin (PTA Studio) et al. arXiv.* [[paper](https://arxiv.org/abs/2308.04026)] [[project page](https://www.agentsims.com/)] [[code](https://github.com/py499372727/AgentSims/)]
 - [2023/07] **S<sup>3</sup>: Social-network Simulation System with Large Language Model-Empowered Agents.** *Chen Gao (Tsinghua University) et al. arXiv.* [[paper](https://arxiv.org/abs/2307.14984)]


### PR DESCRIPTION
Adds CityReal, a human-aligned large-scale LLM-agent urban simulation framework, to section 3.3 Society Simulation.